### PR TITLE
Use unique include guard to fix compilation on MacOSX

### DIFF
--- a/channel.h
+++ b/channel.h
@@ -26,8 +26,8 @@ THE SOFTWARE.
 
 ****************************************************/
 
-#ifndef _CHANNEL_H_
-#define _CHANNEL_H_
+#ifndef _LUAPROC_CHANNEL_H_
+#define _LUAPROC_CHANNEL_H_
 
 #include <pthread.h>
 

--- a/sched.h
+++ b/sched.h
@@ -25,8 +25,8 @@ THE SOFTWARE.
 [sched.h]
 
 ****************************************************/
-#ifndef _SCHED_H_
-#define _SCHED_H_
+#ifndef _LUAPROC_SCHED_H_
+#define _LUAPROC_SCHED_H_
 
 #include "luaproc.h"
 


### PR DESCRIPTION
`_SCHED_H_` is defined by system's library. 
