### PR TITLE
luaproc.newproc() can now take a lua function as an argument

### DIFF
--- a/src/luaproc.c
+++ b/src/luaproc.c
@@ -461,9 +461,9 @@ static int luaproc_get_numworkers( lua_State *L ) {
 static int luaproc_lua_dump( lua_State *L, lua_Writer w,
                              void *data, int strip ) {
 #if LUA_VERSION_NUM >= 503
-	return lua_dump(L, w, data, strip);
+  return lua_dump(L, w, data, strip);
 #else
-	return lua_dump(L, w, data);
+  return lua_dump(L, w, data);
 #endif
 }
 

--- a/src/luaproc.c
+++ b/src/luaproc.c
@@ -383,17 +383,17 @@ static int luaproc_collect_dump( lua_State *L, const void *data,
     out->alloc_len <<= 1;
     if ( out->len + sz > out->alloc_len )
       continue;
-    o = realloc(out->code, out->alloc_len);
+    o = realloc( out->code, out->alloc_len );
     if ( o != NULL ) {
       out->code = (char *) o;
     } else {
-      free(out->code);
+      free( out->code );
       return LUA_ERRMEM;
     }
   }
 
   /* append data to bytecode already collected */
-  memcpy(out->code + out->len, data, sz);
+  memcpy( out->code + out->len, data, sz );
   out->len += sz;
   return 0;
 }
@@ -461,9 +461,9 @@ static int luaproc_get_numworkers( lua_State *L ) {
 static int luaproc_lua_dump( lua_State *L, lua_Writer w,
                              void *data, int strip ) {
 #if LUA_VERSION_NUM >= 503
-  return lua_dump(L, w, data, strip);
+  return lua_dump( L, w, data, strip );
 #else
-  return lua_dump(L, w, data);
+  return lua_dump( L, w, data );
 #endif
 }
 
@@ -516,7 +516,7 @@ static int luaproc_create_newproc( lua_State *L ) {
   lua_pushboolean( L, TRUE );
 
   if ( fdata.alloc_len != 0 )
-    free(fdata.code);
+    free( fdata.code );
 
   return 1;
 }

--- a/src/luaproc.c
+++ b/src/luaproc.c
@@ -479,8 +479,8 @@ static int luaproc_create_newproc( lua_State *L ) {
     fdata.alloc_len = 8;
     if ( luaproc_lua_dump( L, &luaproc_collect_dump, &fdata, 0 ) ) {
       lua_pushstring( L, "luaproc: out of memory or invalid function" );
-    lua_error( L );
-   }
+      lua_error( L );
+    }
   } else {
     fdata.code = (char *) luaL_checkstring( L, 1 );
     fdata.len = strlen( fdata.code );

--- a/src/luaproc.c
+++ b/src/luaproc.c
@@ -8,6 +8,7 @@
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>
+#include <string.h>
 
 #include "luaproc.h"
 #include "lpsched.h"
@@ -261,11 +262,11 @@ void luaproc_queue_receiver( luaproc *lp ) {
 /********************************
  * internal auxiliary functions *
  ********************************/
-static void luaproc_loadstring( lua_State *parent, luaproc *lp,
-                                const char *code ) {
+static void luaproc_loadbuffer( lua_State *parent, luaproc *lp,
+                                const char *code, size_t sz ) {
 
   /* load lua process' lua code */
-  int ret = luaL_loadstring( lp->lstate, code );
+  int ret = luaL_loadbuffer( lp->lstate, code, sz, "luaproc_fn" );
 
   /* in case of errors, close lua_State and push error to parent */
   if ( ret != 0 ) {
@@ -424,12 +425,54 @@ static int luaproc_get_numworkers( lua_State *L ) {
   return 1;
 }
 
+struct dump_collector {
+  int len;
+  int alloc_len;
+  char *code;
+};
+
+static int luaproc_collect_dump( lua_State *L, const void *data,
+                                 size_t sz, void *o ) {
+
+  struct dump_collector *out = (struct dump_collector *) o;
+  /* ensure we have space for the next bytecode chunk */
+  while ( out->len + sz > out->alloc_len ) {
+    out->alloc_len <<= 1;
+    if ( out->len + sz > out->alloc_len )
+      continue;
+    o = realloc(out->code, out->alloc_len);
+    if ( o != NULL ) {
+      out->code = (char *) o;
+    } else {
+      free(out->code);
+      return LUA_ERRMEM;
+    }
+  }
+
+  /* append data to bytecode already collected */
+  memcpy(out->code + out->len, data, sz);
+  out->len += sz;
+  return 0;
+}
+
 /* create and schedule a new lua process */
 static int luaproc_create_newproc( lua_State *L ) {
 
-  /* check if first argument is a string */
-  const char *code = luaL_checkstring( L, 1 );
+  /* check if first argument is a function or a string */
   luaproc *lp;
+  struct dump_collector fdata = { 0, 0, NULL };
+  if ( lua_isfunction( L, 1 ) ) {
+    /* if we have a function, get its bytecode */
+    fdata.code = malloc(8);
+    fdata.alloc_len = 8;
+    if ( lua_dump( L, &luaproc_collect_dump, &fdata ) ) {
+      lua_pushstring( L, "luaproc: out of memory or invalid function" );
+    lua_error( L );
+   }
+  } else {
+    fdata.code = (char *) luaL_checkstring( L, 1 );
+    fdata.len = strlen( fdata.code );
+  }
 
   /* get exclusive access to recycled lua processes list */
   pthread_mutex_lock( &mutex_recycle_list );
@@ -455,10 +498,13 @@ static int luaproc_create_newproc( lua_State *L ) {
 
   /* check code syntax and set lua process ready to execute, 
      or raise an error in corresponding lua state */
-  luaproc_loadstring( L, lp, code );
+  luaproc_loadbuffer( L, lp, fdata.code, fdata.len );
   sched_inc_lpcount();   /* increase active lua process count */
   sched_queue_proc( lp );  /* schedule lua process for execution */
   lua_pushboolean( L, TRUE );
+
+  if ( fdata.alloc_len != 0 )
+    free(fdata.code);
 
   return 1;
 }

--- a/tests/hello.lua
+++ b/tests/hello.lua
@@ -5,7 +5,7 @@ luaproc = require "luaproc"
 luaproc.setnumworkers( 2 )
 
 -- create a new lua process
-luaproc.newproc( [[
+luaproc.newproc( function ()
   -- create a communication channel
   luaproc.newchannel( "achannel" )
   -- create a sender lua process
@@ -18,5 +18,5 @@ luaproc.newproc( [[
     -- receive and print a message
     print( luaproc.receive( "achannel" ))
   ]=] )
-]] )
+end )
 


### PR DESCRIPTION
This pull request modifies the behavior of `luaproc.newproc` to handle the case where it is passed a pure Lua function as an argument. The advantages of passing a Lua function reference instead of a chunk of Lua code are:

* Syntax checking happens when the file is loaded, rather than when the process is created. This is especially useful if the process is not created until some time has passed after startup.

* Syntax highlighting is available in most editors for functions at top-level, but not for functions in longstrings. Most linting and static analysis tools, e.g. `luacheck`, also do not handle functions in longstrings.

* If the function is very long and/or many processes are to be created, using a precompiled chunk saves a significant amount of time parsing/compiling the Lua code.

* Passing a function to `luaproc.newproc()` mirrors the behavior of `coroutine.create()` and is more intuitive for new users.

Of note, using `string.dump()` like this: `luaproc.newproc(string.dump(myfunction))` does *not* work now *and did not work before either*, because `lua_loadstring()` assumes that the chunk it is passed is null-terminated, which means that a bytecode chunk passed from `string.dump()` would often be cut off and generate a `binary string: truncated precompiled chunk` error. The rewritten `luaproc_create_newproc()` uses `strlen()` to get the length of code for `lua_loadbuffer()`, which also expects null-termination, but I didn't think it was a concern because passing a function directly is simpler and it works, and obviously nobody was using `string.dump()` anyway or they would have noticed the errors.

`tests/hello.lua` was also modified to demonstrate both the new and old behavior.

Thanks for continuing to maintain this so many years later :+1: 